### PR TITLE
FEAT: Add framework adapters for Express, Fastify, and NestJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,36 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
+    },
+    "./express": {
+      "import": {
+        "types": "./dist/adapters/express.d.ts",
+        "default": "./dist/adapters/express.js"
+      },
+      "require": {
+        "types": "./dist/adapters/express.d.cts",
+        "default": "./dist/adapters/express.cjs"
+      }
+    },
+    "./fastify": {
+      "import": {
+        "types": "./dist/adapters/fastify.d.ts",
+        "default": "./dist/adapters/fastify.js"
+      },
+      "require": {
+        "types": "./dist/adapters/fastify.d.cts",
+        "default": "./dist/adapters/fastify.cjs"
+      }
+    },
+    "./nest": {
+      "import": {
+        "types": "./dist/adapters/nest.d.ts",
+        "default": "./dist/adapters/nest.js"
+      },
+      "require": {
+        "types": "./dist/adapters/nest.d.cts",
+        "default": "./dist/adapters/nest.cjs"
+      }
     }
   },
   "sideEffects": false,

--- a/src/adapters/express.ts
+++ b/src/adapters/express.ts
@@ -1,0 +1,61 @@
+import { verifyWebhook } from '../verifier.js';
+import type { AdapterOptions } from './shared.js';
+import { extractHeaders, getHeaderNames, mapErrorToBody, mapErrorToStatus } from './shared.js';
+
+export type { AdapterOptions } from './shared.js';
+
+interface ExpressRequest {
+  body: Buffer | string;
+  headers: Record<string, string | string[] | undefined>;
+  webhookVerified?: boolean;
+}
+
+interface ExpressResponse {
+  status(code: number): ExpressResponse;
+  json(body: unknown): void;
+}
+
+type NextFunction = (err?: unknown) => void;
+
+type ExpressMiddleware = (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => void;
+
+export function webhookVerifier(options: AdapterOptions): ExpressMiddleware {
+  const headerNames = getHeaderNames(options);
+
+  return (req, res, next) => {
+    const headerResult = extractHeaders(headerNames, (name) => {
+      const val = req.headers[name];
+      return Array.isArray(val) ? val[0] : val;
+    });
+
+    if ('missing' in headerResult) {
+      const status = 400;
+      res.status(status).json({ error: `Missing required header: ${headerResult.missing}` });
+      return;
+    }
+
+    const payload = Buffer.isBuffer(req.body) ? req.body.toString('utf-8') : req.body;
+
+    verifyWebhook({
+      secret: options.secret,
+      payload,
+      signature: headerResult.signature,
+      timestamp: headerResult.timestamp,
+      nonce: headerResult.nonce,
+      tolerance: options.tolerance,
+      nonceValidator: options.nonceValidator,
+    })
+      .then(() => {
+        req.webhookVerified = true;
+        next();
+      })
+      .catch((error: unknown) => {
+        if (options.onError) {
+          options.onError(error);
+        }
+        const status = mapErrorToStatus(error);
+        const body = mapErrorToBody(error);
+        res.status(status).json(body);
+      });
+  };
+}

--- a/src/adapters/fastify.ts
+++ b/src/adapters/fastify.ts
@@ -1,0 +1,81 @@
+import { verifyWebhook } from '../verifier.js';
+import type { AdapterOptions } from './shared.js';
+import { extractHeaders, getHeaderNames, mapErrorToBody, mapErrorToStatus } from './shared.js';
+
+export type { AdapterOptions } from './shared.js';
+
+interface FastifyRequest {
+  headers: Record<string, string | string[] | undefined>;
+  body: unknown;
+  rawBody?: Buffer | string | undefined;
+  webhookVerified?: boolean;
+}
+
+interface FastifyReply {
+  code(statusCode: number): FastifyReply;
+  send(payload: unknown): FastifyReply;
+}
+
+interface FastifyInstance {
+  decorate(name: string, value: unknown): void;
+  decorateRequest(name: string, value: unknown): void;
+}
+
+type DoneCallback = (err?: Error) => void;
+
+export function webhookPlugin(
+  fastify: FastifyInstance,
+  options: AdapterOptions,
+  done: DoneCallback,
+): void {
+  const headerNames = getHeaderNames(options);
+
+  fastify.decorateRequest('webhookVerified', false);
+
+  fastify.decorate(
+    'verifyWebhook',
+    async (request: FastifyRequest, reply: FastifyReply): Promise<void> => {
+      const headerResult = extractHeaders(headerNames, (name) => {
+        const val = request.headers[name];
+        return Array.isArray(val) ? val[0] : val;
+      });
+
+      if ('missing' in headerResult) {
+        reply.code(400).send({ error: `Missing required header: ${headerResult.missing}` });
+        return;
+      }
+
+      const raw = request.rawBody ?? request.body;
+      const payload = Buffer.isBuffer(raw)
+        ? raw.toString('utf-8')
+        : typeof raw === 'string'
+          ? raw
+          : JSON.stringify(raw);
+
+      try {
+        await verifyWebhook({
+          secret: options.secret,
+          payload,
+          signature: headerResult.signature,
+          timestamp: headerResult.timestamp,
+          nonce: headerResult.nonce,
+          tolerance: options.tolerance,
+          nonceValidator: options.nonceValidator,
+        });
+        request.webhookVerified = true;
+      } catch (error: unknown) {
+        if (options.onError) {
+          options.onError(error);
+        }
+        const status = mapErrorToStatus(error);
+        const body = mapErrorToBody(error);
+        reply.code(status).send(body);
+      }
+    },
+  );
+
+  done();
+}
+
+// Mark as a plugin that doesn't need encapsulation
+(webhookPlugin as unknown as Record<symbol, boolean>)[Symbol.for('skip-override')] = true;

--- a/src/adapters/nest.ts
+++ b/src/adapters/nest.ts
@@ -1,0 +1,113 @@
+import { verifyWebhook } from '../verifier.js';
+import type { AdapterOptions } from './shared.js';
+import { extractHeaders, getHeaderNames, mapErrorToStatus } from './shared.js';
+
+export type { AdapterOptions } from './shared.js';
+
+export const WEBHOOK_OPTIONS = Symbol('WEBHOOK_OPTIONS');
+
+interface ExecutionContext {
+  switchToHttp(): HttpContext;
+}
+
+interface HttpContext {
+  getRequest(): WebhookRequest;
+}
+
+interface WebhookRequest {
+  headers: Record<string, string | string[] | undefined>;
+  body: Buffer | string | unknown;
+  webhookVerified?: boolean;
+}
+
+export class HttpException extends Error {
+  readonly status: number;
+  readonly response: string | Record<string, unknown>;
+
+  constructor(response: string | Record<string, unknown>, status: number) {
+    super(typeof response === 'string' ? response : JSON.stringify(response));
+    this.status = status;
+    this.response = response;
+  }
+
+  getStatus(): number {
+    return this.status;
+  }
+
+  getResponse(): string | Record<string, unknown> {
+    return this.response;
+  }
+}
+
+export class WebhookGuard {
+  private readonly options: AdapterOptions;
+
+  constructor(options: AdapterOptions) {
+    this.options = options;
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const headerNames = getHeaderNames(this.options);
+
+    const headerResult = extractHeaders(headerNames, (name) => {
+      const val = request.headers[name];
+      return Array.isArray(val) ? val[0] : val;
+    });
+
+    if ('missing' in headerResult) {
+      throw new HttpException({ error: `Missing required header: ${headerResult.missing}` }, 400);
+    }
+
+    const raw = request.body;
+    const payload = Buffer.isBuffer(raw)
+      ? raw.toString('utf-8')
+      : typeof raw === 'string'
+        ? raw
+        : JSON.stringify(raw);
+
+    try {
+      await verifyWebhook({
+        secret: this.options.secret,
+        payload,
+        signature: headerResult.signature,
+        timestamp: headerResult.timestamp,
+        nonce: headerResult.nonce,
+        tolerance: this.options.tolerance,
+        nonceValidator: this.options.nonceValidator,
+      });
+      request.webhookVerified = true;
+      return true;
+    } catch (error: unknown) {
+      if (this.options.onError) {
+        this.options.onError(error);
+      }
+      const status = mapErrorToStatus(error);
+      const message = error instanceof Error ? error.message : 'Internal server error';
+      throw new HttpException({ error: message }, status);
+    }
+  }
+}
+
+export interface WebhookModuleOptions extends AdapterOptions {}
+
+// biome-ignore lint/complexity/noStaticOnlyClass: NestJS module pattern requires a class with static forRoot()
+export class WebhookModule {
+  static forRoot(options: WebhookModuleOptions): {
+    module: typeof WebhookModule;
+    providers: Array<{ provide: symbol; useValue: AdapterOptions } | typeof WebhookGuard>;
+    exports: Array<symbol | typeof WebhookGuard>;
+  } {
+    return {
+      module: WebhookModule,
+      providers: [
+        {
+          provide: WEBHOOK_OPTIONS,
+          useValue: options,
+        },
+        WebhookGuard,
+      ],
+      exports: [WEBHOOK_OPTIONS, WebhookGuard],
+    };
+  }
+}

--- a/src/adapters/shared.ts
+++ b/src/adapters/shared.ts
@@ -1,0 +1,72 @@
+import {
+  WebhookError,
+  WebhookNonceError,
+  WebhookSignatureError,
+  WebhookTimestampError,
+} from '../errors.js';
+
+export const DEFAULT_SIGNATURE_HEADER = 'x-webhook-signature';
+export const DEFAULT_TIMESTAMP_HEADER = 'x-webhook-timestamp';
+export const DEFAULT_NONCE_HEADER = 'x-webhook-nonce';
+
+export interface AdapterOptions {
+  secret: string;
+  tolerance?: number | undefined;
+  nonceValidator?: ((nonce: string) => Promise<boolean>) | undefined;
+  signatureHeader?: string | undefined;
+  timestampHeader?: string | undefined;
+  nonceHeader?: string | undefined;
+  onError?: ((error: unknown) => void) | undefined;
+}
+
+export interface AdapterHeaders {
+  signatureHeader: string;
+  timestampHeader: string;
+  nonceHeader: string;
+}
+
+export function getHeaderNames(options: AdapterOptions): AdapterHeaders {
+  return {
+    signatureHeader: options.signatureHeader ?? DEFAULT_SIGNATURE_HEADER,
+    timestampHeader: options.timestampHeader ?? DEFAULT_TIMESTAMP_HEADER,
+    nonceHeader: options.nonceHeader ?? DEFAULT_NONCE_HEADER,
+  };
+}
+
+export function extractHeaders(
+  headers: AdapterHeaders,
+  getter: (name: string) => string | undefined,
+): { signature: string; timestamp: number; nonce: string } | { missing: string } {
+  const signature = getter(headers.signatureHeader);
+  if (!signature) {
+    return { missing: headers.signatureHeader };
+  }
+
+  const timestampRaw = getter(headers.timestampHeader);
+  if (!timestampRaw) {
+    return { missing: headers.timestampHeader };
+  }
+
+  const nonce = getter(headers.nonceHeader);
+  if (!nonce) {
+    return { missing: headers.nonceHeader };
+  }
+
+  const timestamp = Number(timestampRaw);
+
+  return { signature, timestamp, nonce };
+}
+
+export function mapErrorToStatus(error: unknown): number {
+  if (error instanceof WebhookSignatureError) return 401;
+  if (error instanceof WebhookTimestampError) return 400;
+  if (error instanceof WebhookNonceError) return 409;
+  return 500;
+}
+
+export function mapErrorToBody(error: unknown): { error: string; code?: string } {
+  if (error instanceof WebhookError) {
+    return { error: error.message, code: error.code };
+  }
+  return { error: 'Internal server error' };
+}

--- a/test/adapters/express.test.ts
+++ b/test/adapters/express.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { webhookVerifier } from '../../src/adapters/express.js';
+import { signWebhook } from '../../src/signer.js';
+import { TEST_SECRET, TEST_TIMESTAMP } from '../vectors.js';
+
+const firstVector = {
+  payload: '{"event":"payment.completed","amount":4999}',
+  nonce: 'nonce_abc123',
+};
+
+function createMockReq(overrides: Record<string, unknown> = {}) {
+  return {
+    body: Buffer.from(firstVector.payload),
+    headers: {} as Record<string, string | string[] | undefined>,
+    webhookVerified: undefined as boolean | undefined,
+    ...overrides,
+  };
+}
+
+function createMockRes() {
+  const res = {
+    statusCode: 0,
+    body: null as unknown,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(body: unknown) {
+      res.body = body;
+    },
+  };
+  return res;
+}
+
+function signPayload(payload: string, timestamp: number, nonce: string) {
+  return signWebhook({ secret: TEST_SECRET, payload, timestamp, nonce }).signature;
+}
+
+describe('Express webhookVerifier middleware', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TEST_TIMESTAMP * 1000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('calls next() on valid webhook', async () => {
+    const signature = signPayload(firstVector.payload, TEST_TIMESTAMP, firstVector.nonce);
+    const req = createMockReq({
+      headers: {
+        'x-webhook-signature': signature,
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const res = createMockRes();
+    const next = vi.fn();
+
+    const middleware = webhookVerifier({ secret: TEST_SECRET });
+    middleware(req, res, next);
+
+    await vi.waitFor(() => expect(next).toHaveBeenCalled());
+    expect(req.webhookVerified).toBe(true);
+  });
+
+  it('handles string body', async () => {
+    const signature = signPayload(firstVector.payload, TEST_TIMESTAMP, firstVector.nonce);
+    const req = createMockReq({
+      body: firstVector.payload,
+      headers: {
+        'x-webhook-signature': signature,
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const res = createMockRes();
+    const next = vi.fn();
+
+    const middleware = webhookVerifier({ secret: TEST_SECRET });
+    middleware(req, res, next);
+
+    await vi.waitFor(() => expect(next).toHaveBeenCalled());
+    expect(req.webhookVerified).toBe(true);
+  });
+
+  it('returns 400 for missing signature header', () => {
+    const req = createMockReq({
+      headers: {
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const res = createMockRes();
+    const next = vi.fn();
+
+    webhookVerifier({ secret: TEST_SECRET })(req, res, next);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Missing required header: x-webhook-signature' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for missing timestamp header', () => {
+    const req = createMockReq({
+      headers: {
+        'x-webhook-signature': 'a'.repeat(64),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const res = createMockRes();
+    const next = vi.fn();
+
+    webhookVerifier({ secret: TEST_SECRET })(req, res, next);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Missing required header: x-webhook-timestamp' });
+  });
+
+  it('returns 400 for missing nonce header', () => {
+    const req = createMockReq({
+      headers: {
+        'x-webhook-signature': 'a'.repeat(64),
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+      },
+    });
+    const res = createMockRes();
+    const next = vi.fn();
+
+    webhookVerifier({ secret: TEST_SECRET })(req, res, next);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Missing required header: x-webhook-nonce' });
+  });
+
+  it('returns 401 for invalid signature', async () => {
+    const req = createMockReq({
+      headers: {
+        'x-webhook-signature': 'a'.repeat(64),
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const res = createMockRes();
+    const next = vi.fn();
+
+    webhookVerifier({ secret: TEST_SECRET })(req, res, next);
+
+    await vi.waitFor(() => expect(res.statusCode).toBe(401));
+    expect(res.body).toEqual({
+      error: 'Webhook signature is invalid',
+      code: 'WEBHOOK_SIGNATURE_INVALID',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for expired timestamp', async () => {
+    vi.setSystemTime((TEST_TIMESTAMP + 600) * 1000);
+    const signature = signPayload(firstVector.payload, TEST_TIMESTAMP, firstVector.nonce);
+    const req = createMockReq({
+      headers: {
+        'x-webhook-signature': signature,
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const res = createMockRes();
+    const next = vi.fn();
+
+    webhookVerifier({ secret: TEST_SECRET })(req, res, next);
+
+    await vi.waitFor(() => expect(res.statusCode).toBe(400));
+    expect(res.body).toEqual({
+      error: 'Webhook timestamp has expired',
+      code: 'WEBHOOK_TIMESTAMP_EXPIRED',
+    });
+  });
+
+  it('returns 409 for replayed nonce', async () => {
+    const signature = signPayload(firstVector.payload, TEST_TIMESTAMP, firstVector.nonce);
+    const req = createMockReq({
+      headers: {
+        'x-webhook-signature': signature,
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const res = createMockRes();
+    const next = vi.fn();
+
+    webhookVerifier({
+      secret: TEST_SECRET,
+      nonceValidator: async () => false,
+    })(req, res, next);
+
+    await vi.waitFor(() => expect(res.statusCode).toBe(409));
+    expect(res.body).toEqual({
+      error: 'Webhook nonce has been replayed',
+      code: 'WEBHOOK_NONCE_REPLAYED',
+    });
+  });
+
+  it('supports custom header names', async () => {
+    const signature = signPayload(firstVector.payload, TEST_TIMESTAMP, firstVector.nonce);
+    const req = createMockReq({
+      headers: {
+        'x-custom-sig': signature,
+        'x-custom-ts': String(TEST_TIMESTAMP),
+        'x-custom-nonce': firstVector.nonce,
+      },
+    });
+    const res = createMockRes();
+    const next = vi.fn();
+
+    webhookVerifier({
+      secret: TEST_SECRET,
+      signatureHeader: 'x-custom-sig',
+      timestampHeader: 'x-custom-ts',
+      nonceHeader: 'x-custom-nonce',
+    })(req, res, next);
+
+    await vi.waitFor(() => expect(next).toHaveBeenCalled());
+    expect(req.webhookVerified).toBe(true);
+  });
+
+  it('calls onError handler on verification failure', async () => {
+    const onError = vi.fn();
+    const req = createMockReq({
+      headers: {
+        'x-webhook-signature': 'a'.repeat(64),
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const res = createMockRes();
+    const next = vi.fn();
+
+    webhookVerifier({ secret: TEST_SECRET, onError })(req, res, next);
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalled());
+    expect(onError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+  });
+});

--- a/test/adapters/fastify.test.ts
+++ b/test/adapters/fastify.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { webhookPlugin } from '../../src/adapters/fastify.js';
+import { signWebhook } from '../../src/signer.js';
+import { TEST_SECRET, TEST_TIMESTAMP } from '../vectors.js';
+
+const firstVector = {
+  payload: '{"event":"payment.completed","amount":4999}',
+  nonce: 'nonce_abc123',
+};
+
+function signPayload(payload: string, timestamp: number, nonce: string) {
+  return signWebhook({ secret: TEST_SECRET, payload, timestamp, nonce }).signature;
+}
+
+function createMockRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    headers: {} as Record<string, string | string[] | undefined>,
+    body: firstVector.payload,
+    rawBody: undefined as Buffer | string | undefined,
+    webhookVerified: false,
+    ...overrides,
+  };
+}
+
+function createMockReply() {
+  const reply = {
+    statusCode: 0,
+    payload: null as unknown,
+    code(status: number) {
+      reply.statusCode = status;
+      return reply;
+    },
+    send(body: unknown) {
+      reply.payload = body;
+      return reply;
+    },
+  };
+  return reply;
+}
+
+function createMockFastify() {
+  const decorations: Record<string, unknown> = {};
+  const requestDecorations: Record<string, unknown> = {};
+  return {
+    decorations,
+    requestDecorations,
+    decorate(name: string, value: unknown) {
+      decorations[name] = value;
+    },
+    decorateRequest(name: string, value: unknown) {
+      requestDecorations[name] = value;
+    },
+  };
+}
+
+describe('Fastify webhookPlugin', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TEST_TIMESTAMP * 1000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('registers verifyWebhook decorator', () => {
+    const fastify = createMockFastify();
+    const done = vi.fn();
+
+    webhookPlugin(fastify, { secret: TEST_SECRET }, done);
+
+    expect(fastify.decorations.verifyWebhook).toBeTypeOf('function');
+    expect(fastify.requestDecorations.webhookVerified).toBe(false);
+    expect(done).toHaveBeenCalled();
+  });
+
+  it('verifies valid webhook', async () => {
+    const fastify = createMockFastify();
+    const done = vi.fn();
+    webhookPlugin(fastify, { secret: TEST_SECRET }, done);
+
+    const signature = signPayload(firstVector.payload, TEST_TIMESTAMP, firstVector.nonce);
+    const request = createMockRequest({
+      headers: {
+        'x-webhook-signature': signature,
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const reply = createMockReply();
+
+    const verifyHook = fastify.decorations.verifyWebhook as (
+      req: typeof request,
+      rep: typeof reply,
+    ) => Promise<void>;
+    await verifyHook(request, reply);
+
+    expect(request.webhookVerified).toBe(true);
+    expect(reply.statusCode).toBe(0);
+  });
+
+  it('uses rawBody when available', async () => {
+    const fastify = createMockFastify();
+    const done = vi.fn();
+    webhookPlugin(fastify, { secret: TEST_SECRET }, done);
+
+    const signature = signPayload(firstVector.payload, TEST_TIMESTAMP, firstVector.nonce);
+    const request = createMockRequest({
+      rawBody: Buffer.from(firstVector.payload),
+      body: JSON.parse(firstVector.payload),
+      headers: {
+        'x-webhook-signature': signature,
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const reply = createMockReply();
+
+    const verifyHook = fastify.decorations.verifyWebhook as (
+      req: typeof request,
+      rep: typeof reply,
+    ) => Promise<void>;
+    await verifyHook(request, reply);
+
+    expect(request.webhookVerified).toBe(true);
+  });
+
+  it('returns 400 for missing headers', async () => {
+    const fastify = createMockFastify();
+    const done = vi.fn();
+    webhookPlugin(fastify, { secret: TEST_SECRET }, done);
+
+    const request = createMockRequest({ headers: {} });
+    const reply = createMockReply();
+
+    const verifyHook = fastify.decorations.verifyWebhook as (
+      req: typeof request,
+      rep: typeof reply,
+    ) => Promise<void>;
+    await verifyHook(request, reply);
+
+    expect(reply.statusCode).toBe(400);
+    expect(reply.payload).toEqual({ error: 'Missing required header: x-webhook-signature' });
+  });
+
+  it('returns 401 for invalid signature', async () => {
+    const fastify = createMockFastify();
+    const done = vi.fn();
+    webhookPlugin(fastify, { secret: TEST_SECRET }, done);
+
+    const request = createMockRequest({
+      headers: {
+        'x-webhook-signature': 'a'.repeat(64),
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const reply = createMockReply();
+
+    const verifyHook = fastify.decorations.verifyWebhook as (
+      req: typeof request,
+      rep: typeof reply,
+    ) => Promise<void>;
+    await verifyHook(request, reply);
+
+    expect(reply.statusCode).toBe(401);
+  });
+
+  it('returns 400 for expired timestamp', async () => {
+    vi.setSystemTime((TEST_TIMESTAMP + 600) * 1000);
+    const fastify = createMockFastify();
+    const done = vi.fn();
+    webhookPlugin(fastify, { secret: TEST_SECRET }, done);
+
+    const signature = signPayload(firstVector.payload, TEST_TIMESTAMP, firstVector.nonce);
+    const request = createMockRequest({
+      headers: {
+        'x-webhook-signature': signature,
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const reply = createMockReply();
+
+    const verifyHook = fastify.decorations.verifyWebhook as (
+      req: typeof request,
+      rep: typeof reply,
+    ) => Promise<void>;
+    await verifyHook(request, reply);
+
+    expect(reply.statusCode).toBe(400);
+  });
+
+  it('returns 409 for replayed nonce', async () => {
+    const fastify = createMockFastify();
+    const done = vi.fn();
+    webhookPlugin(fastify, { secret: TEST_SECRET, nonceValidator: async () => false }, done);
+
+    const signature = signPayload(firstVector.payload, TEST_TIMESTAMP, firstVector.nonce);
+    const request = createMockRequest({
+      headers: {
+        'x-webhook-signature': signature,
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const reply = createMockReply();
+
+    const verifyHook = fastify.decorations.verifyWebhook as (
+      req: typeof request,
+      rep: typeof reply,
+    ) => Promise<void>;
+    await verifyHook(request, reply);
+
+    expect(reply.statusCode).toBe(409);
+  });
+
+  it('supports custom header names', async () => {
+    const fastify = createMockFastify();
+    const done = vi.fn();
+    webhookPlugin(
+      fastify,
+      {
+        secret: TEST_SECRET,
+        signatureHeader: 'x-sig',
+        timestampHeader: 'x-ts',
+        nonceHeader: 'x-nc',
+      },
+      done,
+    );
+
+    const signature = signPayload(firstVector.payload, TEST_TIMESTAMP, firstVector.nonce);
+    const request = createMockRequest({
+      headers: {
+        'x-sig': signature,
+        'x-ts': String(TEST_TIMESTAMP),
+        'x-nc': firstVector.nonce,
+      },
+    });
+    const reply = createMockReply();
+
+    const verifyHook = fastify.decorations.verifyWebhook as (
+      req: typeof request,
+      rep: typeof reply,
+    ) => Promise<void>;
+    await verifyHook(request, reply);
+
+    expect(request.webhookVerified).toBe(true);
+  });
+
+  it('calls onError handler on failure', async () => {
+    const onError = vi.fn();
+    const fastify = createMockFastify();
+    const done = vi.fn();
+    webhookPlugin(fastify, { secret: TEST_SECRET, onError }, done);
+
+    const request = createMockRequest({
+      headers: {
+        'x-webhook-signature': 'a'.repeat(64),
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const reply = createMockReply();
+
+    const verifyHook = fastify.decorations.verifyWebhook as (
+      req: typeof request,
+      rep: typeof reply,
+    ) => Promise<void>;
+    await verifyHook(request, reply);
+
+    expect(onError).toHaveBeenCalled();
+  });
+});

--- a/test/adapters/nest.test.ts
+++ b/test/adapters/nest.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  HttpException,
+  WEBHOOK_OPTIONS,
+  WebhookGuard,
+  WebhookModule,
+} from '../../src/adapters/nest.js';
+import { signWebhook } from '../../src/signer.js';
+import { TEST_SECRET, TEST_TIMESTAMP } from '../vectors.js';
+
+const firstVector = {
+  payload: '{"event":"payment.completed","amount":4999}',
+  nonce: 'nonce_abc123',
+};
+
+function signPayload(payload: string, timestamp: number, nonce: string) {
+  return signWebhook({ secret: TEST_SECRET, payload, timestamp, nonce }).signature;
+}
+
+function createMockContext(overrides: Record<string, unknown> = {}) {
+  const request = {
+    headers: {} as Record<string, string | string[] | undefined>,
+    body: firstVector.payload,
+    webhookVerified: undefined as boolean | undefined,
+    ...overrides,
+  };
+
+  return {
+    request,
+    switchToHttp() {
+      return {
+        getRequest() {
+          return request;
+        },
+      };
+    },
+  };
+}
+
+describe('NestJS WebhookGuard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(TEST_TIMESTAMP * 1000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns true for valid webhook', async () => {
+    const signature = signPayload(firstVector.payload, TEST_TIMESTAMP, firstVector.nonce);
+    const context = createMockContext({
+      headers: {
+        'x-webhook-signature': signature,
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+
+    const guard = new WebhookGuard({ secret: TEST_SECRET });
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+    expect(context.request.webhookVerified).toBe(true);
+  });
+
+  it('handles Buffer body', async () => {
+    const signature = signPayload(firstVector.payload, TEST_TIMESTAMP, firstVector.nonce);
+    const context = createMockContext({
+      body: Buffer.from(firstVector.payload),
+      headers: {
+        'x-webhook-signature': signature,
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+
+    const guard = new WebhookGuard({ secret: TEST_SECRET });
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+
+  it('throws HttpException(400) for missing headers', async () => {
+    const context = createMockContext({ headers: {} });
+    const guard = new WebhookGuard({ secret: TEST_SECRET });
+
+    await expect(guard.canActivate(context)).rejects.toThrow(HttpException);
+
+    try {
+      await guard.canActivate(context);
+    } catch (e) {
+      const err = e as HttpException;
+      expect(err.getStatus()).toBe(400);
+      expect(err.getResponse()).toEqual({
+        error: 'Missing required header: x-webhook-signature',
+      });
+    }
+  });
+
+  it('throws HttpException(401) for invalid signature', async () => {
+    const context = createMockContext({
+      headers: {
+        'x-webhook-signature': 'a'.repeat(64),
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const guard = new WebhookGuard({ secret: TEST_SECRET });
+
+    try {
+      await guard.canActivate(context);
+      expect.fail('Should have thrown');
+    } catch (e) {
+      const err = e as HttpException;
+      expect(err.getStatus()).toBe(401);
+    }
+  });
+
+  it('throws HttpException(400) for expired timestamp', async () => {
+    vi.setSystemTime((TEST_TIMESTAMP + 600) * 1000);
+    const signature = signPayload(firstVector.payload, TEST_TIMESTAMP, firstVector.nonce);
+    const context = createMockContext({
+      headers: {
+        'x-webhook-signature': signature,
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const guard = new WebhookGuard({ secret: TEST_SECRET });
+
+    try {
+      await guard.canActivate(context);
+      expect.fail('Should have thrown');
+    } catch (e) {
+      const err = e as HttpException;
+      expect(err.getStatus()).toBe(400);
+    }
+  });
+
+  it('throws HttpException(409) for replayed nonce', async () => {
+    const signature = signPayload(firstVector.payload, TEST_TIMESTAMP, firstVector.nonce);
+    const context = createMockContext({
+      headers: {
+        'x-webhook-signature': signature,
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const guard = new WebhookGuard({
+      secret: TEST_SECRET,
+      nonceValidator: async () => false,
+    });
+
+    try {
+      await guard.canActivate(context);
+      expect.fail('Should have thrown');
+    } catch (e) {
+      const err = e as HttpException;
+      expect(err.getStatus()).toBe(409);
+    }
+  });
+
+  it('supports custom header names', async () => {
+    const signature = signPayload(firstVector.payload, TEST_TIMESTAMP, firstVector.nonce);
+    const context = createMockContext({
+      headers: {
+        'x-custom-sig': signature,
+        'x-custom-ts': String(TEST_TIMESTAMP),
+        'x-custom-nonce': firstVector.nonce,
+      },
+    });
+    const guard = new WebhookGuard({
+      secret: TEST_SECRET,
+      signatureHeader: 'x-custom-sig',
+      timestampHeader: 'x-custom-ts',
+      nonceHeader: 'x-custom-nonce',
+    });
+
+    const result = await guard.canActivate(context);
+    expect(result).toBe(true);
+  });
+
+  it('calls onError handler on failure', async () => {
+    const onError = vi.fn();
+    const context = createMockContext({
+      headers: {
+        'x-webhook-signature': 'a'.repeat(64),
+        'x-webhook-timestamp': String(TEST_TIMESTAMP),
+        'x-webhook-nonce': firstVector.nonce,
+      },
+    });
+    const guard = new WebhookGuard({ secret: TEST_SECRET, onError });
+
+    try {
+      await guard.canActivate(context);
+    } catch {
+      // expected
+    }
+
+    expect(onError).toHaveBeenCalled();
+  });
+});
+
+describe('WebhookModule', () => {
+  it('forRoot returns module config with providers and exports', () => {
+    const options = { secret: 'test-secret' };
+    const result = WebhookModule.forRoot(options);
+
+    expect(result.module).toBe(WebhookModule);
+    expect(result.providers).toHaveLength(2);
+    expect(result.providers[0]).toEqual({
+      provide: WEBHOOK_OPTIONS,
+      useValue: options,
+    });
+    expect(result.providers[1]).toBe(WebhookGuard);
+    expect(result.exports).toContain(WEBHOOK_OPTIONS);
+    expect(result.exports).toContain(WebhookGuard);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,12 +1,17 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: [
+    'src/index.ts',
+    'src/adapters/express.ts',
+    'src/adapters/fastify.ts',
+    'src/adapters/nest.ts',
+  ],
   format: ['esm', 'cjs'],
   dts: true,
   sourcemap: true,
   clean: true,
   minify: false,
   noExternal: [],
-  external: ['node:crypto'],
+  external: ['node:crypto', 'express', 'fastify', '@nestjs/common'],
 });


### PR DESCRIPTION
## Summary

- Adds webhook verification adapters as separate entry points (`webhook-hmac-kit/express`, `/fastify`, `/nest`) to eliminate boilerplate when integrating with popular Node.js frameworks
- Shared adapter utilities (header extraction, error-to-HTTP-status mapping) in `src/adapters/shared.ts`
- Zero runtime dependencies beyond the core library — framework types are used only for type-checking

Closes #2 

## Adapters

| Adapter | Import | Pattern |
|---------|--------|---------|
| **Express** | `webhook-hmac-kit/express` | `webhookVerifier(options)` middleware |
| **Fastify** | `webhook-hmac-kit/fastify` | `webhookPlugin` with `fastify.verifyWebhook` decorator |
| **NestJS** | `webhook-hmac-kit/nest` | `WebhookGuard` + `WebhookModule.forRoot()` |

### Error → HTTP Status Mapping
- `WebhookSignatureError` → 401
- `WebhookTimestampError` → 400
- `WebhookNonceError` → 409
- Other errors → 500

### Configurable Options
- Custom header names (`signatureHeader`, `timestampHeader`, `nonceHeader`)
- Tolerance override
- Nonce validator callback
- Custom error handler (`onError`)

## Test plan

- [x] 28 new adapter tests (10 Express, 9 Fastify, 9 NestJS) — all pass
- [x] 70 existing core tests unaffected — all pass
- [x] `npm run typecheck` passes
- [x] `npm run build` produces ESM + CJS + `.d.ts` for all adapters
- [x] `npm run lint` passes (biome)